### PR TITLE
Update the role to be able to use local installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ In most case we need CNTLM to set enterprise proxy in order to acces to internet
 
 ## Role variables
 
+* `cntlm_package_file`: Configure path to package file (rpm or deb) (string, NO DEFAULT). If not specified, CNTLM is downloaded from sourceforge.
+* `cntlm_config_file`: Name of the configuration file of CNTLM (`string`, default: `/etc/cntlm.conf`)
+* `cntlm_service_name`: Name of the CNTLM service (`string`, default: `cntlmd`)
 * `cntlm_version`: Configure CNTLM version to install (`string`, default: `0.92.3`)
 * `cntlm_config_template`: Configure path to template for CNTLM configuration file *cntlm.conf* (`string`, default: `cntlm.conf.j2`)
 * `cntlm_username`: Configure cntlm username (`string`, default: `testuser`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 
+cntlm_config_file: /etc/cntlm.conf
+cntlm_service_name: cntlmd
+
 cntlm_version: 0.92.3
 # per ansible_os_family versions (on sourceforge)
 cntlm_os_family_versions:

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -1,7 +1,15 @@
 ---
 
-- name: Install CNTLM for enterprise proxy
+- name: Install CNTLM for enterprise proxy (local)
+  tags: cntlm
+  apt:
+     deb: /tmp/{{ cntlm_package_file | basename }}
+     state: present
+  when: cntlm_package_file is defined
+
+- name: Install CNTLM for enterprise proxy (sourceforge)
   tags: cntlm
   apt: >
     deb="https://downloads.sourceforge.net/project/cntlm/cntlm/cntlm%20{{ cntlm_version }}/cntlm_{{ cntlm_version_sourceforge }}_amd64.deb"
     state=present
+  when: cntlm_package_file is not defined

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -1,7 +1,15 @@
 ---
 
-- name: Install CNTLM for enterprise proxy
+- name: Install CNTLM for enterprise proxy (local)
+  tags: cntlm
+  yum:
+     name: /tmp/{{ cntlm_package_file | basename }}
+     state: present
+  when: cntlm_package_file is defined
+
+- name: Install CNTLM for enterprise proxy (sourceforge)
   tags: cntlm
   yum: >
     name="https://downloads.sourceforge.net/project/cntlm/cntlm/cntlm%20{{ cntlm_version }}/cntlm_{{ cntlm_version_sourceforge }}.x86_64.rpm"
     state=present
+  when: cntlm_package_file is not defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: Copy package to server
+  copy:
+     src: "{{ cntlm_package_file }}"
+     dest: "/tmp/{{ cntlm_package_file | basename }}"
+  when: cntlm_package_file is defined
+
 - include: install-redhat.yml
   when: ansible_os_family == 'RedHat'
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,0 @@
----
-
-cntlm_config_file: /etc/cntlm.conf
-cntlm_service_name: cntlmd


### PR DESCRIPTION
Hello,

CNTLM could be use to access Internet through the enterprise proxy. In this case, if CNTLM is not installed, internet is not available. I updated the role to be able to specify a local path to the CNTLM package. If the local path is not specified, CNTLM will be downloaded from sourceforge if possible.

Thanks.